### PR TITLE
Add kind and apiversion as env vars to shell process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,12 @@ watch:
 
 ### CRD input
 
-The operator will expose environment variables into the shell environment when the script is run to allow the script to identify the namespace and name of the object that has changed. The values are:
+The operator will expose environment variables into the shell environment when the script is run to allow the script to identify the namespace and name of the object that has changed as well as the type. The values are:
 
 * SHOP_OBJECT_NAMESPACE
 * SHOP_OBJECT_NAME
+* SHOP_API_VERSION
+* SHOP_KIND
 * Any other variables you have listed in the `environment` key of the YAML config for that watch (see example above).
 
 You can reference these environment variables in your script and use a Kubernetes API call or kubectl to get information on the object that has changed or is being reconciled.

--- a/pkg/watcher/controller.go
+++ b/pkg/watcher/controller.go
@@ -12,12 +12,16 @@ import (
 )
 
 const (
-	NameEnvVarKey      = "SHOP_OBJECT_NAME"
-	NamespaceEnvVarKey = "SHOP_OBJECT_NAMESPACE"
+	NameEnvVarKey       = "SHOP_OBJECT_NAME"
+	NamespaceEnvVarKey  = "SHOP_OBJECT_NAMESPACE"
+	APIVersionEnvVarKey = "SHOP_API_VERSION"
+	KindEnvVarKey       = "SHOP_KIND"
 )
 
 type ShellReconciler struct {
-	Command string
+	Command          string
+	ObjectKind       string
+	ObjectApiVersion string
 }
 
 func (s *ShellReconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) {
@@ -25,8 +29,10 @@ func (s *ShellReconciler) Reconcile(req reconcile.Request) (reconcile.Result, er
 
 	glog.V(4).Infof("Setting up shell command %s for %s/%s...", s.Command, req.Namespace, req.Name)
 	cmd := executor.SetupShellCommand(s.Command, map[string]string{
-		NameEnvVarKey:      req.Name,
-		NamespaceEnvVarKey: req.Namespace,
+		NameEnvVarKey:       req.Name,
+		NamespaceEnvVarKey:  req.Namespace,
+		APIVersionEnvVarKey: s.ObjectApiVersion,
+		KindEnvVarKey:       s.ObjectKind,
 	})
 
 	glog.V(4).Infof("Running command %s...", s.Command)
@@ -52,7 +58,9 @@ func SetupWatches(mgr manager.Manager, shellConfig *ShellConfig) error {
 			controller.Options{
 				MaxConcurrentReconciles: watch.Concurrency,
 				Reconciler: &ShellReconciler{
-					Command: watch.Command,
+					Command:          watch.Command,
+					ObjectApiVersion: watch.ApiVersion,
+					ObjectKind:       watch.Kind,
 				},
 			},
 		)


### PR DESCRIPTION
This allows the process to ascertain the type for generic wrappers.