### PR TITLE
Thread context from main and call cancel on SIGTERM.

### DIFF
--- a/pkg/shell/testdata/test-script
+++ b/pkg/shell/testdata/test-script
@@ -1,5 +1,13 @@
 #! /bin/bash
 
+cleanup() {
+  echo "recieved term"
+  sleep 5
+  echo "exiting after cleanup"
+}
+
+trap cleanup SIGTERM
+
 echo "first line"
 
 >&2 echo "error first line"

--- a/pkg/watcher/controller_test.go
+++ b/pkg/watcher/controller_test.go
@@ -1,6 +1,7 @@
 package watcher
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -9,7 +10,11 @@ import (
 )
 
 func TestReconcilerRunsShellCmd(t *testing.T) {
-	recon := ShellReconciler{Command: "bash -c echo $SHOP_OBJECT_NAME $SHOP_OBJECT_NAMESPACE > /tmp/shop-test1", Timeout: time.Duration(1)}
+	recon := ShellReconciler{
+		Command: "bash -c echo $SHOP_OBJECT_NAME $SHOP_OBJECT_NAMESPACE > /tmp/shop-test1",
+		Timeout: time.Duration(1),
+		ctx:     context.Background(),
+	}
 	req := reconcile.Request{types.NamespacedName{Name: "test-object", Namespace: "ns1"}}
 
 	res, err := recon.Reconcile(req)
@@ -24,7 +29,11 @@ func TestReconcilerRunsShellCmd(t *testing.T) {
 }
 
 func TestReconcilerFailedShellCommand(t *testing.T) {
-	recon := ShellReconciler{Command: "exit 1", Timeout: time.Duration(1)}
+	recon := ShellReconciler{
+		Command: "exit 1",
+		Timeout: time.Duration(1),
+		ctx:     context.Background(),
+	}
 	req := reconcile.Request{types.NamespacedName{Name: "test-object", Namespace: "ns1"}}
 
 	res, err := recon.Reconcile(req)


### PR DESCRIPTION
This PR threads a context all the way to reconciler calls so that when the app receives a SIGTERM we can then call cancel on the context to cleanup everything. 

Currently the exec Cmd will actually do a process KILL when the context is cancelled or times out. We need to wrap some of the functionality with a SIGTERM then sleep at some point later.