### PR TITLE
Add in metrics for prometheus and healthcheck endpoint.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  branch = "master"
+  digest = "1:d6afaeed1502aa28e80a4ed0981d570ad91b2579193404256ce672ed0a609e0d"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  pruneopts = "UT"
+  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
+
+[[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -165,6 +173,14 @@
   revision = "81af80346b1a01caae0cbc27fd3c1ba5b11e189f"
 
 [[projects]]
+  digest = "1:ff5ebae34cfbf047d505ee150de27e60570e8c394b3b8fdbb720ff6ac71985fc"
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  pruneopts = "UT"
+  revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
+  version = "v1.0.1"
+
+[[projects]]
   digest = "1:33422d238f147d247752996a26574ac48dcf472976eda7f5134015f06bf16563"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
@@ -203,6 +219,50 @@
   pruneopts = "UT"
   revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
   version = "v2.0.1"
+
+[[projects]]
+  digest = "1:d14a5f4bfecf017cb780bdde1b6483e5deb87e12c332544d2c430eda58734bcb"
+  name = "github.com/prometheus/client_golang"
+  packages = [
+    "prometheus",
+    "prometheus/promhttp",
+  ]
+  pruneopts = "UT"
+  revision = "c5b7fccd204277076155f10851dad72b76a49317"
+  version = "v0.8.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:2d5cd61daa5565187e1d96bae64dbbc6080dacf741448e9629c64fd93203b0d4"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  pruneopts = "UT"
+  revision = "5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f"
+
+[[projects]]
+  branch = "master"
+  digest = "1:63b68062b8968092eb86bedc4e68894bd096ea6b24920faca8b9dcf451f54bb5"
+  name = "github.com/prometheus/common"
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model",
+  ]
+  pruneopts = "UT"
+  revision = "c7de2306084e37d54b8be01f3541a8464345e9a5"
+
+[[projects]]
+  branch = "master"
+  digest = "1:ef74914912f99c79434d9c09658274678bc85080ebe3ab32bec3940ebce5e1fc"
+  name = "github.com/prometheus/procfs"
+  packages = [
+    ".",
+    "internal/util",
+    "nfs",
+    "xfs",
+  ]
+  pruneopts = "UT"
+  revision = "185b4288413d2a0dd0806f78c90dde719829e5ae"
 
 [[projects]]
   digest = "1:c1b1102241e7f645bc8e0c22ae352e8f0dc6484b6cb4d132fa9f24174e0119e2"
@@ -531,6 +591,8 @@
   input-imports = [
     "github.com/golang/glog",
     "github.com/golang/mock/gomock",
+    "github.com/prometheus/client_golang/prometheus",
+    "github.com/prometheus/client_golang/prometheus/promhttp",
     "gopkg.in/yaml.v2",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/runtime",

--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ The operator will expose environment variables into the shell environment when t
 
 You can reference these environment variables in your script and use a Kubernetes API call or kubectl to get information on the object that has changed or is being reconciled.
 
+## Observability
+
+Shell Operator has a metrics endpoint built in that you can point Prometheus at. This will allow you to see how many runs are occuring, which ones are failing and the average time in milliseconds on a per watch basis.
+
+The endpoint is running on port 8080 at `/metrics` with a healthcheck at `/healthz` that you can use for liveness probes.
+
+See [pkg/metrics/metrics.go](pkg/metrics/metrics.go) for the list of available metrics.
+
 ## Development
 
 The repo is enabled with docker and docker-compose. To run tests execute `docker-compose run test`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     build:
       context: .
       target: base
+    ports:
+      - "8080:8080"
     volumes:
       - ".:/go/src/github.com/MYOB-Technology/shell-operator"
       - "$HOME/.kube:/root/.kube"

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	shopconfig "github.com/MYOB-Technology/shell-operator/pkg/config"
+	"github.com/MYOB-Technology/shell-operator/pkg/metrics"
 	"github.com/MYOB-Technology/shell-operator/pkg/shell"
 	"github.com/MYOB-Technology/shell-operator/pkg/watcher"
 
@@ -54,6 +55,8 @@ func main() {
 	if err != nil {
 		glog.Fatal(err)
 	}
+
+	go func() { glog.Fatal(metrics.RunServer("8080")) }()
 
 	// Run any boot commands
 	for _, b := range shellConfig.Boot {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,54 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	ApiVersionLabel = "api_version"
+	KindLabel       = "kind"
+)
+
+var (
+	successRuns = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "shelloperator_success_runs",
+		Help: "Number of successful shell executions that have occured, where success is a zero exit code.",
+	}, []string{ApiVersionLabel, KindLabel})
+
+	failureRuns = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "shelloperator_failure_runs",
+		Help: "Number of failed shell executions that have occured, where failed is a non zero exit code.",
+	}, []string{ApiVersionLabel, KindLabel})
+
+	shellRunTime = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "shelloperator_run_time_milliseconds",
+		Help: "The time it takes for shell executions to run as a histogram in milliseconds.",
+	}, []string{ApiVersionLabel, KindLabel})
+)
+
+func init() {
+	prometheus.MustRegister(successRuns)
+	prometheus.MustRegister(failureRuns)
+	prometheus.MustRegister(shellRunTime)
+}
+
+func IncSuccessRun(apiVersion, kind string) {
+	successRuns.With(prometheus.Labels{
+		ApiVersionLabel: apiVersion,
+		KindLabel:       kind,
+	}).Inc()
+}
+
+func IncFailureRun(apiVersion, kind string) {
+	failureRuns.With(prometheus.Labels{
+		ApiVersionLabel: apiVersion,
+		KindLabel:       kind,
+	}).Inc()
+}
+
+func ObserveRunTime(apiVersion, kind string, milliseconds float64) {
+	shellRunTime.With(prometheus.Labels{
+		ApiVersionLabel: apiVersion,
+		KindLabel:       kind,
+	}).Observe(milliseconds)
+}

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -1,0 +1,18 @@
+package metrics
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+func healthCheck(res http.ResponseWriter, _ *http.Request) {
+	res.WriteHeader(200)
+	res.Write([]byte("OK"))
+}
+
+func RunServer(port string) error {
+	http.HandleFunc("/healthz", healthCheck)
+	http.Handle("/metrics", promhttp.Handler())
+	return http.ListenAndServe(":"+port, nil)
+}


### PR DESCRIPTION
Adding metrics so that you can monitor how many runs your watches are doing and the time they take to run.